### PR TITLE
Avoid code repetition

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,0 @@
-pub fn u8_as_string(byte_arr: &[u8]) -> String {
-    let mut out_str = String::new();
-    for byte in byte_arr {
-        out_str.push(*byte as char);
-    }
-    out_str
-}


### PR DESCRIPTION
I tried to use rust macros to avoid some repetition.

Misc changes:
- put contents of `utils.rs` into `lib.rs`
- `*HeaderData` enums should be public if they aren't used in the public API