### PR TITLE
Create MobiMetadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@ pub(crate) use reader::Reader;
 pub use record::Record;
 use std::{fs, io, io::Read, ops::Range, path::Path};
 
-
 #[derive(Debug, Default)]
 /// Structure that holds parsed ebook information and contents
 pub struct Mobi {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,11 @@
 //!     let contributor = m.contributor().unwrap_or(&empty);
 //!
 //!     // Access Headers
-//!     let header = &m.header; // Normal Header
-//!     let pdheader = &m.palmdoc; // PalmDOC Header
-//!     let mheader = &m.mobi; // MOBI Header
-//!     let exth = &m.exth; // Extra Header
+//!     let metadata = &m.metadata;
+//!     let header = &metadata.header; // Normal Header
+//!     let pdheader = &metadata.palmdoc; // PalmDOC Header
+//!     let mheader = &metadata.mobi; // MOBI Header
+//!     let exth = &metadata.exth; // Extra Header
 //!
 //!     // Access content
 //!     let content = m.content_as_string();
@@ -57,33 +58,42 @@ pub(crate) use reader::Reader;
 pub use record::Record;
 use std::{fs, io, io::Read, ops::Range, path::Path};
 
+
 #[derive(Debug, Default)]
 /// Structure that holds parsed ebook information and contents
 pub struct Mobi {
     pub raw_content: Vec<u8>,
+    pub metadata: MobiMetadata,
+    pub records: Vec<Record>,
+}
+
+#[derive(Debug, Default)]
+/// Structure that holds parsed ebook information
+pub struct MobiMetadata {
     pub header: Header,
     pub palmdoc: PalmDocHeader,
     pub mobi: MobiHeader,
     pub exth: ExtHeader,
-    pub records: Vec<Record>,
 }
-impl Mobi {
-    /// Construct a Mobi object from a slice
-    pub fn new<B: AsRef<Vec<u8>>>(bytes: B) -> io::Result<Mobi> {
-        Mobi::from_reader(Reader::new(bytes.as_ref()))
-    }
-    /// Construct a Mobi object from passed file path
-    pub fn from_path<P: AsRef<Path>>(file_path: P) -> io::Result<Mobi> {
-        Mobi::new(&fs::read(file_path)?)
-    }
-    /// Construct a Mobi object from an object that implements a Read trait
-    pub fn from_read<R: Read>(reader: R) -> io::Result<Mobi> {
-        // Temporary solution
-        let content: Vec<_> = reader.bytes().flatten().collect();
-        Mobi::from_reader(Reader::new(&content))
+
+impl MobiMetadata {
+    /// Construct a MobiMetadata object from a slice
+    pub fn new<B: AsRef<Vec<u8>>>(bytes: B) -> io::Result<MobiMetadata> {
+        MobiMetadata::from_reader(&mut Reader::new(bytes.as_ref()))
     }
 
-    fn from_reader(mut reader: Reader) -> io::Result<Mobi> {
+    /// Construct a MobiMetadata object from passed file path
+    pub fn from_path<P: AsRef<Path>>(file_path: P) -> io::Result<MobiMetadata> {
+        MobiMetadata::new(&fs::read(file_path)?)
+    }
+
+    /// Construct a MobiMetadata object from an object that implements a Read trait
+    pub fn from_read<R: Read>(reader: R) -> io::Result<MobiMetadata> {
+        let content: Vec<_> = reader.bytes().flatten().collect();
+        MobiMetadata::from_reader(&mut Reader::new(&content))
+    }
+
+    fn from_reader(mut reader: &mut Reader) -> io::Result<MobiMetadata> {
         let header = Header::parse(&mut reader)?;
         reader.set_num_of_records(header.num_of_records);
         let palmdoc = PalmDocHeader::parse(&mut reader)?;
@@ -95,19 +105,12 @@ impl Mobi {
                 ExtHeader::default()
             }
         };
-        let records = Record::parse_records(
-            reader.content_ref(),
-            header.num_of_records,
-            mobi.extra_bytes,
-            palmdoc.compression_enum(),
-        )?;
-        Ok(Mobi {
-            raw_content: reader.content(),
+
+        Ok(MobiMetadata {
             header,
             palmdoc,
             mobi,
             exth,
-            records,
         })
     }
 
@@ -139,6 +142,7 @@ impl Mobi {
     pub fn title(&self) -> Option<&String> {
         self.exth.get_record(exth::ExthRecord::Title)
     }
+
     /// Returns text encoding used in ebook
     pub fn text_encoding(&self) -> TextEncoding {
         self.mobi.text_encoding()
@@ -163,10 +167,12 @@ impl Mobi {
     pub fn mod_datetime(&self) -> NaiveDateTime {
         self.header.mod_datetime()
     }
+
     /// Returns creation time as u32 timestamp
     pub fn created_time(&self) -> u32 {
         self.header.created_datetime()
     }
+
     /// Returns last modification time as u32 timestamp
     pub fn mod_time(&self) -> u32 {
         self.header.mod_datetime()
@@ -184,6 +190,115 @@ impl Mobi {
     /// Returns last readable index of the book
     fn last_index(&self) -> usize {
         (self.palmdoc.record_count - 1) as usize
+    }
+}
+
+impl Mobi {
+    /// Construct a Mobi object from a slice
+    pub fn new<B: AsRef<Vec<u8>>>(bytes: B) -> io::Result<Mobi> {
+        Mobi::from_reader(&mut Reader::new(bytes.as_ref()))
+    }
+    /// Construct a Mobi object from passed file path
+    pub fn from_path<P: AsRef<Path>>(file_path: P) -> io::Result<Mobi> {
+        Mobi::new(&fs::read(file_path)?)
+    }
+    /// Construct a Mobi object from an object that implements a Read trait
+    pub fn from_read<R: Read>(reader: R) -> io::Result<Mobi> {
+        // Temporary solution
+        let content: Vec<_> = reader.bytes().flatten().collect();
+        Mobi::from_reader(&mut Reader::new(&content))
+    }
+
+    fn from_reader(reader: &mut Reader) -> io::Result<Mobi> {
+        let metadata = MobiMetadata::from_reader(reader)?;
+        let records = Record::parse_records(
+            reader.content_ref(),
+            metadata.header.num_of_records,
+            metadata.mobi.extra_bytes,
+            metadata.palmdoc.compression_enum(),
+        )?;
+        Ok(Mobi {
+            raw_content: reader.content(),
+            metadata,
+            records,
+        })
+    }
+
+    /// Returns author record if such exists
+    pub fn author(&self) -> Option<&String> {
+        self.metadata.author()
+    }
+    /// Returns publisher record if such exists
+    pub fn publisher(&self) -> Option<&String> {
+        self.metadata.publisher()
+    }
+    /// Returns description record if such exists
+    pub fn description(&self) -> Option<&String> {
+        self.metadata.description()
+    }
+    /// Returns isbn record if such exists
+    pub fn isbn(&self) -> Option<&String> {
+        self.metadata.isbn()
+    }
+    /// Returns publish_date record if such exists
+    pub fn publish_date(&self) -> Option<&String> {
+        self.metadata.publish_date()
+    }
+    /// Returns contributor record if such exists
+    pub fn contributor(&self) -> Option<&String> {
+        self.metadata.contributor()
+    }
+    /// Returns title record if such exists
+    pub fn title(&self) -> Option<&String> {
+        self.metadata.title()
+    }
+    /// Returns text encoding used in ebook
+    pub fn text_encoding(&self) -> TextEncoding {
+        self.metadata.text_encoding()
+    }
+    /// Returns type of this ebook
+    pub fn mobi_type(&self) -> Option<String> {
+        self.metadata.mobi_type()
+    }
+    /// Returns language of the ebook
+    pub fn language(&self) -> Option<String> {
+        self.metadata.language()
+    }
+    #[cfg(feature = "time")]
+    /// Returns creation datetime
+    /// This field is only available using `time` feature
+    pub fn created_datetime(&self) -> NaiveDateTime {
+        self.metadata.created_datetime()
+    }
+    #[cfg(feature = "time")]
+    /// Returns modification datetime
+    /// This field is only available using `time` feature
+    pub fn mod_datetime(&self) -> NaiveDateTime {
+        self.metadata.mod_datetime()
+    }
+
+    /// Returns creation time as u32 timestamp
+    pub fn created_time(&self) -> u32 {
+        self.metadata.created_time()
+    }
+
+    /// Returns last modification time as u32 timestamp
+    pub fn mod_time(&self) -> u32 {
+        self.metadata.mod_time()
+    }
+
+    /// Returns compression method used on this file
+    pub fn compression(&self) -> String {
+        self.metadata.compression()
+    }
+    /// Returns encryption method used on this file
+    pub fn encryption(&self) -> String {
+        self.metadata.encryption()
+    }
+
+    /// Returns last readable index of the book
+    fn last_index(&self) -> usize {
+        self.metadata.last_index()
     }
 
     fn readable_records_range(&self) -> Range<usize> {


### PR DESCRIPTION
Since it looks like the headers depend on each other to behave correctly (eg. the user must use MobiHeader to create to create ExtHeader), it seems like exposing this interface as a single unified class which creates everything at once is the best choice.

At the moment, a lot of methods between Mobi and MobiMetadata are duplicated - I'm not sure how you want to expose those functions, so I haven't modified things too much.