### PR TITLE
Add CLI testing for Windows, MacOS, non-current Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: rust
-
+rust:
+  - stable
+  - 1.40.0
+  
 os:
   - linux
+  - windows
+  - osx
 
 before_install:
   - rustup component add clippy rustfmt


### PR DESCRIPTION
I think it would be a good to ensure this crate doesn't have any strange edge cases on other operating systems and doesn't break unexpectedly for previous versions of Rust.