### PR TITLE
Clean up code & optimization

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -185,7 +185,6 @@ Flis record:            {}",
 
 impl fmt::Display for Mobi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let empty_str = String::from("");
         write!(
             f,
             "
@@ -206,13 +205,13 @@ Contributor:            {}
 ------------------------------------------------------------------------------------
 {}
 ------------------------------------------------------------------------------------",
-            self.title().unwrap_or(&empty_str),
-            self.author().unwrap_or(&empty_str),
-            self.publisher().unwrap_or(&empty_str),
-            self.description().unwrap_or(&empty_str),
-            self.isbn().unwrap_or(&empty_str),
-            self.publish_date().unwrap_or(&empty_str),
-            self.contributor().unwrap_or(&empty_str),
+            self.title().unwrap_or_default(),
+            self.author().unwrap_or_default(),
+            self.publisher().unwrap_or_default(),
+            self.description().unwrap_or_default(),
+            self.isbn().unwrap_or_default(),
+            self.publish_date().unwrap_or_default(),
+            self.contributor().unwrap_or_default(),
             self.metadata.header,
             self.metadata.palmdoc,
             self.metadata.mobi,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,20 +199,19 @@ impl Mobi {
     /// There are only two supported encodings in mobi format (UTF8, WIN1252)
     /// and both are losely converted by this function
     pub fn content_as_string(&self) -> io::Result<String> {
-        let records = self.records()?;
-        Ok(self
-            .readable_records_range()
-            .map(|i| records[i as usize].to_string(self.text_encoding()))
+        Ok(self.records()?[self.readable_records_range()]
+            .iter()
+            .map(|record| record.to_string(self.text_encoding()))
             .collect())
     }
 
     /// Returns all readable records content decompressed as a Vec
     pub fn content(&self) -> io::Result<Vec<u8>> {
-        let records = self.records()?;
-        Ok(self
-            .readable_records_range()
-            .map(|i| records[i as usize].record_data.clone())
-            .flatten()
-            .collect())
+        let records = &self.records()?[self.readable_records_range()];
+        let mut record_data = Vec::with_capacity(records.iter().map(|r| r.record_data.len()).sum());
+        for record in records {
+            record_data.extend_from_slice(&record.record_data);
+        }
+        Ok(record_data)
     }
 }


### PR DESCRIPTION
The original content fn takes about 0.0572s on average to return the content, while the new content fn takes 0.0468s on average with all changes (benchmark times were produced by checking how long m.content() took to process the records for a broad selection of mobi files, using cargo --release and the time after 3 successive runs for both versions).

I also took the time to clean up parse_records, as the original implementation was hard to understand - the new implementation is hopefully more direct and easier to understand (and a little faster, since we don't do the insertion / removal and we also get rid of the clones). I tested that the two implementations produced identical records on a selection of mobis I had (though I don't think I can upload these for testing).

Additionally, I think it would be a good idea to add a comment explaining why readable_records_range() starts at 1 and not 0, to avoid any possible confusion (seems like it should be 0..record_len - 1, since the last record is empty?).

If you wanted to clean up the code a little bit more and make the tests more obvious, I think you could replace code like this
```rust
vec![57, 55, 56, 48, 50, 54, 49, 49, 48, 50, 51, 49, 54]
```
with the easier to understand
```rust
b"9780261102316".to_vec()
```
but that's a matter of personal preference.