### PR TITLE
Add writing for header.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "indexmap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +111,7 @@ version = "0.5.1"
 dependencies = [
  "chrono",
  "encoding",
+ "indexmap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "mobi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "mobi"
 [dependencies]
 chrono = { version = "0.4", optional = true }
 encoding = "0.2.0"
-
+indexmap = "1.6.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/headers/exth.rs
+++ b/src/headers/exth.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
-use crate::reader::Reader;
-use std::{collections::HashMap, io};
+use crate::reader::{Reader, Writer};
+use indexmap::IndexMap;
+use std::io;
 
 // Records available in EXTH header
 pub enum ExthRecord {
@@ -78,7 +79,7 @@ pub struct ExtHeader {
     pub identifier: u32,
     pub header_length: u32,
     pub record_count: u32,
-    pub records: HashMap<u32, Vec<u8>>,
+    pub records: IndexMap<u32, Vec<u8>>,
 }
 
 impl ExtHeader {
@@ -89,7 +90,7 @@ impl ExtHeader {
             identifier: reader.read_u32_be()?,
             header_length: reader.read_u32_be()?,
             record_count: reader.read_u32_be()?,
-            records: HashMap::new(),
+            records: IndexMap::new(),
         };
 
         extheader.populate_records(reader)?;
@@ -108,6 +109,19 @@ impl ExtHeader {
             self.records.insert(record_type, record_data);
         }
 
+        Ok(())
+    }
+
+    pub(crate) fn write<W: io::Write>(&self, w: &mut Writer<W>) -> io::Result<()> {
+        w.write_be(self.identifier)?;
+        // 12 for first 12 bytes, 8 per record + len.
+        w.write_be(12u32 + self.records.iter().map(|(_, d)| 8 + d.len() as u32).sum::<u32>())?;
+        w.write_be(self.records.len() as u32)?;
+        for (&id, record_data) in self.records.iter() {
+            w.write_be(id)?;
+            w.write_be(record_data.len() as u32 + 8)?;
+            w.write_be(record_data)?;
+        }
         Ok(())
     }
 
@@ -132,10 +146,11 @@ impl ExtHeader {
 mod tests {
     use super::*;
     use crate::book;
+    use crate::reader::Writer;
 
     #[test]
-    fn parse() {
-        let mut records = HashMap::new();
+    fn test_parse() {
+        let mut records = IndexMap::new();
         #[rustfmt::skip]
         let _records = vec![
             (104, b"9780261102316".to_vec()),
@@ -159,6 +174,7 @@ mod tests {
             record_count: 11,
             records,
         };
+
         let mut reader = book::u8_reader(book::BOOK.to_vec());
         let parsed_header = ExtHeader::parse(&mut reader).unwrap();
         for (k, v) in &extheader.records {
@@ -167,6 +183,17 @@ mod tests {
             assert_eq!(v, record.unwrap());
         }
         assert_eq!(extheader, parsed_header);
+    }
+
+    #[test]
+    fn test_write() {
+        let bookx = book::BOOK[0..book::BOOK.len() - 44].to_vec();
+        let mut reader = book::u8_reader(bookx.clone());
+        let parsed_header = ExtHeader::parse(&mut reader).unwrap();
+        let mut buf = vec![];
+        parsed_header.write(&mut Writer::new(&mut buf)).unwrap();
+        // assert_eq!(bookx.len(), buf.len());
+        assert_eq!(bookx, buf);
     }
 
     mod records {

--- a/src/headers/exth.rs
+++ b/src/headers/exth.rs
@@ -187,13 +187,19 @@ mod tests {
 
     #[test]
     fn test_write() {
-        let bookx = book::BOOK[0..book::BOOK.len() - 44].to_vec();
+        // First ExtHeader has duplicated fields and will not match when written.
+        let bookx = book::BOOK.to_vec();
         let mut reader = book::u8_reader(bookx.clone());
         let parsed_header = ExtHeader::parse(&mut reader).unwrap();
         let mut buf = vec![];
         parsed_header.write(&mut Writer::new(&mut buf)).unwrap();
-        // assert_eq!(bookx.len(), buf.len());
-        assert_eq!(bookx, buf);
+
+        // Create a new one with no duplicate fields, which will be identical
+        let new_exth_header = ExtHeader::parse(&mut book::u8_reader(buf.clone())).unwrap();
+        let mut buf2 = vec![];
+        new_exth_header.write(&mut Writer::new(&mut buf2)).unwrap();
+
+        assert_eq!(buf, buf2);
     }
 
     mod records {

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -49,9 +49,7 @@ impl Header {
         w.write_be(self.attributes)?;
         w.write_be(self.version)?;
         w.write_be(self.created)?;
-        #[cfg(feature = "time")]
-        w.write_be(chrono::offset::Utc::now().timestamp() as u32);
-        #[cfg(not(feature = "time"))]
+        // User should change this themselves?
         w.write_be(self.modified)?;
         w.write_be(self.backup)?;
         w.write_be(self.modnum)?;

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -49,6 +49,9 @@ impl Header {
         w.write_be(self.attributes)?;
         w.write_be(self.version)?;
         w.write_be(self.created)?;
+        #[cfg(feature = "time")]
+        w.write_be(chrono::offset::Utc::now().timestamp() as u32);
+        #[cfg(not(feature = "time"))]
         w.write_be(self.modified)?;
         w.write_be(self.backup)?;
         w.write_be(self.modnum)?;
@@ -114,6 +117,7 @@ mod tests {
             next_record_list_id: 0,
             num_records: 292,
         };
+
         let mut reader = book::u8_reader(book::HEADER.to_vec());
         let parsed_header = Header::parse(&mut reader);
         assert_eq!(header, parsed_header.unwrap())

--- a/src/headers/header.rs
+++ b/src/headers/header.rs
@@ -44,7 +44,7 @@ impl Header {
         })
     }
 
-    pub(crate) fn write<W: io::Write>(&self, w: &mut Writer<W>) -> io::Result<()> {
+    pub(crate) fn write<W: io::Write>(&self, w: &mut Writer<W>, num_records: u16) -> io::Result<()> {
         w.write_string_be(&self.name, 32)?;
         w.write_be(self.attributes)?;
         w.write_be(self.version)?;
@@ -58,7 +58,7 @@ impl Header {
         w.write_string_be(&self.creator, 4)?;
         w.write_be(self.unique_id_seed)?;
         w.write_be(self.next_record_list_id)?;
-        w.write_be(self.num_records)
+        w.write_be(num_records)
     }
 
     #[cfg(feature = "time")]
@@ -128,7 +128,7 @@ mod tests {
 
         let mut buf = vec![];
 
-        parsed_header.write(&mut Writer::new(&mut buf)).unwrap();
+        parsed_header.write(&mut Writer::new(&mut buf), 292).unwrap();
         assert_eq!(header.len(), buf.len());
         assert_eq!(header, buf);
     }

--- a/src/headers/mobih.rs
+++ b/src/headers/mobih.rs
@@ -1,3 +1,4 @@
+use crate::reader::Writer;
 use crate::Reader;
 use std::io;
 
@@ -10,7 +11,54 @@ pub enum TextEncoding {
     UTF8,
 }
 
-#[derive(Debug, PartialEq, Default)]
+impl Default for MobiHeader {
+    fn default() -> Self {
+        MobiHeader {
+            identifier: 0,
+            header_length: 0,
+            mobi_type: 0,
+            text_encoding: 0,
+            id: 0,
+            gen_version: 0,
+            ortho_index: 0xFFFF_FFFF,
+            inflect_index: 0xFFFF_FFFF,
+            index_names: 0xFFFF_FFFF,
+            index_keys: 0xFFFF_FFFF,
+            extra_indices: [0xFFFF_FFFF; 6],
+            first_non_book_index: 0,
+            name_offset: 0,
+            name_length: 0,
+            unused: 0,
+            locale: 0,
+            language_code: 0,
+            input_language: 0,
+            output_language: 0,
+            format_version: 0,
+            first_image_index: 0,
+            first_huff_record: 0,
+            huff_record_count: 0,
+            huff_table_offset: 0,
+            huff_table_length: 0,
+            exth_flags: 0,
+            unused_0: Box::new([0; 32]),
+            unused_1: 0xFFFF_FFFF,
+            drm_offset: 0,
+            drm_count: 0,
+            drm_size: 0,
+            drm_flags: 0,
+            unused_2: Box::new([0; 8]),
+            first_content_record: 1,
+            last_content_record: 0,
+            unused_3: 1,
+            fcis_record: 0,
+            unused_4: 1,
+            flis_record: 0,
+            unused_5: vec![],
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 /// Strcture that holds Mobi header information
 pub struct MobiHeader {
     pub identifier: u32,
@@ -19,81 +67,157 @@ pub struct MobiHeader {
     pub text_encoding: u32,
     pub id: u32,
     pub gen_version: u32,
+    pub ortho_index: u32,
+    pub inflect_index: u32,
+    pub index_names: u32,
+    pub index_keys: u32,
+    pub extra_indices: [u32; 6],
     pub first_non_book_index: u32,
     pub name_offset: u32,
     pub name_length: u32,
-    pub language_code: u16,
+    unused: u16,
+    pub locale: u8,
+    pub language_code: u8,
     pub input_language: u32,
     pub output_language: u32,
     pub format_version: u32,
     pub first_image_index: u32,
     pub first_huff_record: u32,
     pub huff_record_count: u32,
-    pub first_data_record: u32,
-    pub data_record_count: u32,
+    pub huff_table_offset: u32,
+    pub huff_table_length: u32,
     pub exth_flags: u32,
+    unused_0: Box<[u8; 32]>,
+    unused_1: u32,
     pub drm_offset: u32,
     pub drm_count: u32,
     pub drm_size: u32,
     pub drm_flags: u32,
-    pub last_image_record: u16,
+    unused_2: Box<[u8; 8]>,
+    pub first_content_record: u16,
+    pub last_content_record: u16,
+    unused_3: u32,
     pub fcis_record: u32,
+    unused_4: u32,
     pub flis_record: u32,
+    unused_5: Vec<u8>,
 }
 
 impl MobiHeader {
     /// Parse a Mobi header from the content. The reader must be advanced to the starting
     /// position of the Mobi header.
     pub(crate) fn parse<R: io::Read>(reader: &mut Reader<R>) -> io::Result<MobiHeader> {
-        let start_position = reader.get_position();
+        let identifier = reader.read_u32_be()?;
+        let header_length = reader.read_u32_be()?;
 
-        let m = MobiHeader {
-            identifier: reader.read_u32_be()?,
-            header_length: reader.read_u32_be()?,
+        Ok(MobiHeader {
+            identifier,
+            header_length,
             mobi_type: reader.read_u32_be()?,
             text_encoding: reader.read_u32_be()?,
             id: reader.read_u32_be()?,
             gen_version: reader.read_u32_be()?,
-            first_non_book_index: {
-                reader.set_position(reader.get_position() + 40)?;
-                reader.read_u32_be()?
-            },
+            ortho_index: reader.read_u32_be()?,
+            inflect_index: reader.read_u32_be()?,
+            index_names: reader.read_u32_be()?,
+            index_keys: reader.read_u32_be()?,
+            extra_indices: [
+                reader.read_u32_be()?,
+                reader.read_u32_be()?,
+                reader.read_u32_be()?,
+                reader.read_u32_be()?,
+                reader.read_u32_be()?,
+                reader.read_u32_be()?,
+            ],
+            first_non_book_index: reader.read_u32_be()?,
             name_offset: reader.read_u32_be()?,
             name_length: reader.read_u32_be()?,
-            language_code: MobiHeader::lang_code(reader.read_u32_be()?),
+            unused: reader.read_u16_be()?,
+            locale: reader.read_u8()?,
+            language_code: reader.read_u8()?,
             input_language: reader.read_u32_be()?,
             output_language: reader.read_u32_be()?,
             format_version: reader.read_u32_be()?,
             first_image_index: reader.read_u32_be()?,
             first_huff_record: reader.read_u32_be()?,
             huff_record_count: reader.read_u32_be()?,
-            first_data_record: reader.read_u32_be()?,
-            data_record_count: reader.read_u32_be()?,
+            huff_table_offset: reader.read_u32_be()?,
+            huff_table_length: reader.read_u32_be()?,
             exth_flags: reader.read_u32_be()?,
-            drm_offset: {
-                reader.set_position(reader.get_position() + 36)?;
-                reader.read_u32_be()?
+            unused_0: {
+                let mut bytes = [0; 32];
+                reader.read_exact(&mut bytes)?;
+                Box::new(bytes)
             },
+            unused_1: reader.read_u32_be()?,
+            drm_offset: reader.read_u32_be()?,
             drm_count: reader.read_u32_be()?,
             drm_size: reader.read_u32_be()?,
             drm_flags: reader.read_u32_be()?,
-            last_image_record: {
-                reader.set_position(reader.get_position() + 10)?;
-                reader.read_u16_be()?
+            unused_2: {
+                let mut bytes = [0; 8];
+                reader.read_exact(&mut bytes)?;
+                Box::new(bytes)
             },
-            fcis_record: {
-                reader.read_u32_be()?;
-                reader.read_u32_be()?
+            first_content_record: reader.read_u16_be()?,
+            last_content_record: reader.read_u16_be()?,
+            unused_3: reader.read_u32_be()?,
+            fcis_record: reader.read_u32_be()?,
+            unused_4: reader.read_u32_be()?,
+            flis_record: reader.read_u32_be()?,
+            unused_5: {
+                let mut unused = vec![0; header_length as usize - 196];
+                reader.read_exact(&mut unused)?;
+                unused
             },
-            flis_record: {
-                reader.read_u32_be()?;
-                reader.read_u32_be()?
-            },
-        };
+        })
+    }
 
-        reader.set_position(start_position + m.header_length as usize)?;
-
-        Ok(m)
+    /// Parse a Mobi header from the content. The reader must be advanced to the starting
+    /// position of the Mobi header.
+    pub(crate) fn write<W: io::Write>(&self, w: &mut Writer<W>) -> io::Result<()> {
+        w.write_be(self.identifier)?;
+        w.write_be(self.header_length)?;
+        w.write_be(self.mobi_type)?;
+        w.write_be(self.text_encoding)?;
+        w.write_be(self.id)?;
+        w.write_be(self.gen_version)?;
+        w.write_be(self.ortho_index)?;
+        w.write_be(self.inflect_index)?;
+        w.write_be(self.index_names)?;
+        w.write_be(self.index_keys)?;
+        for &i in &self.extra_indices {
+            w.write_be(i)?;
+        }
+        w.write_be(self.first_non_book_index)?;
+        w.write_be(self.name_offset)?;
+        w.write_be(self.name_length)?;
+        w.write_be(self.unused)?;
+        w.write_be(self.locale)?;
+        w.write_be(self.language_code)?;
+        w.write_be(self.input_language)?;
+        w.write_be(self.output_language)?;
+        w.write_be(self.format_version)?;
+        w.write_be(self.first_image_index)?;
+        w.write_be(self.first_huff_record)?;
+        w.write_be(self.huff_record_count)?;
+        w.write_be(self.huff_table_offset)?;
+        w.write_be(self.huff_table_length)?;
+        w.write_be(self.exth_flags)?;
+        w.write_be(self.unused_0.as_ref().as_ref())?;
+        w.write_be(self.unused_1)?;
+        w.write_be(self.drm_offset)?;
+        w.write_be(self.drm_count)?;
+        w.write_be(self.drm_size)?;
+        w.write_be(self.drm_flags)?;
+        w.write_be(self.unused_2.as_ref().as_ref())?;
+        w.write_be(self.first_content_record)?;
+        w.write_be(self.last_content_record)?;
+        w.write_be(self.unused_3)?;
+        w.write_be(self.fcis_record)?;
+        w.write_be(self.unused_4)?;
+        w.write_be(self.flis_record)?;
+        w.write_be(self.unused_5.as_slice())
     }
 
     /// Checks if there is a Exth Header and changes the parameter
@@ -138,10 +262,6 @@ impl MobiHeader {
             65001 => TextEncoding::UTF8,
             n => panic!("Unknown encoding {}", n),
         }
-    }
-
-    fn lang_code(code: u32) -> u16 {
-        (code & 0xFF) as u16
     }
 
     pub(crate) fn language(&self) -> Option<String> {
@@ -234,10 +354,11 @@ impl MobiHeader {
 #[cfg(test)]
 mod tests {
     use super::MobiHeader;
+    use crate::reader::Writer;
     use crate::{book, TextEncoding};
 
     #[test]
-    fn parse() {
+    fn test_parse() {
         let mobiheader = MobiHeader {
             identifier: 1297039945,
             header_length: 232,
@@ -245,9 +366,16 @@ mod tests {
             text_encoding: 65001,
             id: 3428045761,
             gen_version: 6,
+            ortho_index: 0xFFFF_FFFF,
+            inflect_index: 0xFFFF_FFFF,
+            index_names: 0xFFFF_FFFF,
+            index_keys: 0xFFFF_FFFF,
+            extra_indices: [0xFFFF_FFFF; 6],
             first_non_book_index: 284,
             name_offset: 1360,
             name_length: 42,
+            unused: 0,
+            locale: 8,
             language_code: 9,
             input_language: 0,
             output_language: 0,
@@ -255,16 +383,26 @@ mod tests {
             first_image_index: 287,
             first_huff_record: 0,
             huff_record_count: 0,
-            first_data_record: 0,
-            data_record_count: 0,
+            huff_table_offset: 0,
+            huff_table_length: 0,
             exth_flags: 80,
             drm_offset: 4294967295,
             drm_count: 0,
             drm_size: 0,
             drm_flags: 0,
-            last_image_record: 288,
+            first_content_record: 1,
+            last_content_record: 288,
             fcis_record: 290,
             flis_record: 289,
+            unused_0: Box::new([0; 32]),
+            unused_1: 0xFFFF_FFFF,
+            unused_2: Box::new([0, 0, 0, 0, 0, 0, 0, 0]),
+            unused_3: 1,
+            unused_4: 1,
+            unused_5: vec![
+                0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255,
+                255, 0, 0, 0, 7, 0, 0, 1, 28,
+            ],
         };
 
         let mut reader = book::u8_reader(book::MOBIHEADER.to_vec());
@@ -274,85 +412,53 @@ mod tests {
     }
 
     #[test]
+    fn test_drm() {
+        let mobiheader = MobiHeader {
+            drm_offset: 1,
+            ..Default::default()
+        };
+
+        assert!(mobiheader.has_drm());
+    }
+
+    #[test]
     fn test_no_drm() {
         let mobiheader = MobiHeader {
-            identifier: 1297039945,
-            header_length: 232,
-            mobi_type: 2,
-            text_encoding: 65001,
-            id: 3428045761,
-            gen_version: 6,
-            first_non_book_index: 284,
-            name_offset: 1360,
-            name_length: 42,
-            language_code: 9,
-            input_language: 0,
-            output_language: 0,
-            format_version: 6,
-            first_image_index: 287,
-            first_huff_record: 0,
-            huff_record_count: 0,
-            first_data_record: 0,
-            data_record_count: 0,
-            exth_flags: 80,
-            drm_offset: 4294967295,
-            drm_count: 0,
-            drm_size: 0,
-            drm_flags: 0,
-            last_image_record: 288,
-            fcis_record: 290,
-            flis_record: 289,
+            drm_offset: 0xFFFF_FFFF,
+            ..Default::default()
         };
 
         assert!(!mobiheader.has_drm());
     }
 
     #[test]
-    fn test_drm() {
-        let mobiheader = MobiHeader {
-            identifier: 1297039945,
-            header_length: 232,
-            mobi_type: 2,
-            text_encoding: 65001,
-            id: 3428045761,
-            gen_version: 6,
-            first_non_book_index: 284,
-            name_offset: 1360,
-            name_length: 42,
-            language_code: 9,
-            input_language: 0,
-            output_language: 0,
-            format_version: 6,
-            first_image_index: 287,
-            first_huff_record: 0,
-            huff_record_count: 0,
-            first_data_record: 0,
-            data_record_count: 0,
-            exth_flags: 80,
-            drm_offset: 1,
-            drm_count: 0,
-            drm_size: 0,
-            drm_flags: 0,
-            last_image_record: 288,
-            fcis_record: 290,
-            flis_record: 289,
-        };
+    fn test_write() {
+        let input_bytes = book::MOBIHEADER.to_vec();
 
-        assert!(mobiheader.has_drm());
+        let mobiheader = MobiHeader::parse(&mut book::u8_reader(input_bytes.clone())).unwrap();
+
+        let mut output_bytes = vec![];
+        assert!(mobiheader.write(&mut Writer::new(&mut output_bytes)).is_ok());
+        assert_eq!(input_bytes.len(), output_bytes.len());
+        assert_eq!(input_bytes, output_bytes);
     }
 
     mod text_encoding {
         use super::*;
         #[test]
         fn utf_8() {
-            let mut m = MobiHeader::default();
-            m.text_encoding = 65001;
+            let m = MobiHeader {
+                text_encoding: 65001,
+                ..Default::default()
+            };
             assert_eq!(m.text_encoding(), TextEncoding::UTF8)
         }
         #[test]
         fn win_latin1() {
-            let mut m = MobiHeader::default();
-            m.text_encoding = 1252;
+            let m = MobiHeader {
+                text_encoding: 1252,
+                ..Default::default()
+            };
             assert_eq!(m.text_encoding(), TextEncoding::CP1252)
         }
     }
@@ -361,8 +467,10 @@ mod tests {
     fn parses_mobi_types() {
         macro_rules! mtype {
             ($mt: expr, $s: expr) => {
-                let mut m = MobiHeader::default();
-                m.mobi_type = $mt;
+                let m = MobiHeader {
+                    mobi_type: $mt,
+                    ..Default::default()
+                };
                 assert_eq!(m.mobi_type(), Some(String::from($s)))
             };
         }
@@ -384,8 +492,10 @@ mod tests {
     fn parses_languages() {
         macro_rules! lang {
             ($lc: expr, $s: expr) => {
-                let mut m = MobiHeader::default();
-                m.language_code = $lc;
+                let m = MobiHeader {
+                    language_code: $lc,
+                    ..Default::default()
+                };
                 assert_eq!(m.language(), Some(String::from($s)))
             };
         }

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -72,7 +72,7 @@ impl MobiMetadata {
 
     pub(crate) fn write(&self, writer: &mut impl io::Write) -> io::Result<()> {
         let mut w = Writer::new(writer);
-        self.header.write(&mut w)?;
+        self.header.write(&mut w, self.records.num_records())?;
         self.records.write(&mut w)?;
         self.palmdoc.write(&mut w)?;
         self.mobi.write(&mut w)?;

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -213,17 +213,21 @@ mod test {
 
     #[test]
     fn test_mobi_write() {
-        let full_book = book::full_book();
-        let mut reader = book::u8_reader(full_book.clone());
-        let m = MobiMetadata::from_reader(&mut reader).unwrap();
+        // First write will lose duplicate ExtHeader records.
+        let m = MobiMetadata::from_reader(&mut book::u8_reader(book::full_book())).unwrap();
         let mut bytes = vec![];
         assert!(m.write(&mut bytes).is_ok());
-        assert_eq!(bytes.len(), full_book.len());
 
-        for (i, (w1, w2)) in bytes.chunks(8).zip(full_book.chunks(8)).enumerate() {
-            assert_eq!(w1, w2, "{}", i * 8);
-        }
+        // No duplicates, should work correctly.
+        let m1 = MobiMetadata::from_reader(&mut book::u8_reader(bytes.clone())).unwrap();
+        let mut bytes1 = vec![];
+        assert!(m1.write(&mut bytes1).is_ok());
 
-        assert_eq!(bytes, book::full_book());
+        let m2 = MobiMetadata::from_reader(&mut book::u8_reader(bytes1.clone())).unwrap();
+        let mut bytes2 = vec![];
+        assert!(m2.write(&mut bytes2).is_ok());
+
+        assert_eq!(bytes1.len(), bytes2.len());
+        assert_eq!(bytes1, bytes2);
     }
 }

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -70,14 +70,17 @@ impl MobiMetadata {
         })
     }
 
-    pub(crate) fn write(&self, writer: &mut impl io::Write) -> io::Result<()> {
-        let mut w = Writer::new(writer);
-        self.header.write(&mut w, self.records.num_records())?;
-        self.records.write(&mut w)?;
-        self.palmdoc.write(&mut w)?;
-        self.mobi.write(&mut w)?;
+    fn write(&self, writer: &mut impl io::Write) -> io::Result<()> {
+        self.write_into(&mut Writer::new(writer))
+    }
+
+    pub(crate) fn write_into<W: io::Write>(&self, w: &mut Writer<W>) -> io::Result<()> {
+        self.header.write(w, self.records.num_records())?;
+        self.records.write(w)?;
+        self.palmdoc.write(w)?;
+        self.mobi.write(w)?;
         if self.mobi.has_exth_header() {
-            self.exth.write(&mut w)?;
+            self.exth.write(w)?;
         }
 
         let fill = ((self.records.records[0].0 + self.mobi.name_offset) as usize).saturating_sub(w.bytes_written());

--- a/src/headers/palmdoch.rs
+++ b/src/headers/palmdoch.rs
@@ -1,4 +1,4 @@
-use crate::reader::Reader;
+use crate::reader::{Reader, Writer};
 use std::io;
 
 /// Compression types available in MOBI format.
@@ -56,9 +56,11 @@ impl ToString for Encryption {
 pub struct PalmDocHeader {
     pub compression: u16,
     pub text_length: u32,
+    unused0: u16,
     pub record_count: u16,
     pub record_size: u16,
     pub encryption_type: u16,
+    unused1: u16,
 }
 
 impl PalmDocHeader {
@@ -67,18 +69,23 @@ impl PalmDocHeader {
     pub(crate) fn parse<R: io::Read>(reader: &mut Reader<R>) -> io::Result<PalmDocHeader> {
         Ok(PalmDocHeader {
             compression: reader.read_u16_be()?,
-            text_length: {
-                reader.read_u16_be()?;
-                reader.read_u32_be()?
-            },
+            unused0: reader.read_u16_be()?,
+            text_length: reader.read_u32_be()?,
             record_count: reader.read_u16_be()?,
             record_size: reader.read_u16_be()?,
-            encryption_type: {
-                let b = reader.read_u16_be()?;
-                reader.read_u16_be()?;
-                b
-            },
+            encryption_type: reader.read_u16_be()?,
+            unused1: reader.read_u16_be()?,
         })
+    }
+
+    pub(crate) fn write<W: io::Write>(&self, w: &mut Writer<W>) -> io::Result<()> {
+        w.write_be(self.compression)?;
+        w.write_be(self.unused0)?;
+        w.write_be(self.text_length)?;
+        w.write_be(self.record_count)?;
+        w.write_be(self.record_size)?;
+        w.write_be(self.encryption_type)?;
+        w.write_be(self.unused1)
     }
 
     pub(crate) fn compression(&self) -> String {
@@ -107,11 +114,23 @@ mod tests {
             record_count: 282,
             record_size: 4096,
             encryption_type: 0,
+            ..Default::default()
         };
 
         let mut reader = book::u8_reader(book::PALMDOCHEADER.to_vec());
 
         assert_eq!(pdheader, PalmDocHeader::parse(&mut reader).unwrap());
+    }
+
+    #[test]
+    fn test_write() {
+        let input_bytes = book::PALMDOCHEADER.to_vec();
+
+        let palmdoc = PalmDocHeader::parse(&mut book::u8_reader(input_bytes.clone())).unwrap();
+
+        let mut output_bytes = vec![];
+        assert!(palmdoc.write(&mut Writer::new(&mut output_bytes)).is_ok());
+        assert_eq!(input_bytes, output_bytes);
     }
 
     mod compression_type {

--- a/src/headers/records.rs
+++ b/src/headers/records.rs
@@ -1,4 +1,4 @@
-use crate::reader::Reader;
+use crate::reader::{Reader, Writer};
 use std::io;
 
 const EXTRA_BYTES_FLAG: u16 = 0xFFFE;
@@ -12,7 +12,7 @@ const EXTRA_BYTES_FLAG: u16 = 0xFFFE;
 #[derive(Debug, PartialEq, Default)]
 pub struct Records {
     pub records: Vec<(u32, u32)>,
-    pub extra_bytes: u32,
+    extra_bytes: u16,
 }
 
 impl Records {
@@ -25,12 +25,22 @@ impl Records {
             records.push((reader.read_u32_be()?, reader.read_u32_be()?));
         }
 
-        let extra_bytes = reader.read_u16_be()?;
-
         Ok(Records {
             records,
-            extra_bytes: 2 * (extra_bytes & EXTRA_BYTES_FLAG).count_ones(),
+            extra_bytes: reader.read_u16_be()?,
         })
+    }
+
+    pub fn extra_bytes(&self) -> u32 {
+        2 * (self.extra_bytes & EXTRA_BYTES_FLAG).count_ones() as u32
+    }
+
+    pub(crate) fn write<W: io::Write>(&self, w: &mut Writer<W>) -> io::Result<()> {
+        for &record in &self.records {
+            w.write_be(record.0)?;
+            w.write_be(record.1)?;
+        }
+        w.write_be(self.extra_bytes)
     }
 }
 
@@ -43,5 +53,16 @@ mod test {
     fn parse() {
         let mut reader = book::u8_reader(book::RECORDS.to_vec());
         assert!(Records::parse(&mut reader, 292).is_ok());
+    }
+
+    #[test]
+    fn test_write() {
+        let records = book::RECORDS.to_vec();
+        let mut reader = book::u8_reader(records.clone());
+        let record = Records::parse(&mut reader, 292).unwrap();
+        let mut written = Vec::new();
+        record.write(&mut Writer::new(&mut written)).unwrap();
+        assert_eq!(records.len(), written.len());
+        assert_eq!(records, written);
     }
 }

--- a/src/headers/records.rs
+++ b/src/headers/records.rs
@@ -35,6 +35,10 @@ impl Records {
         2 * (self.extra_bytes & EXTRA_BYTES_FLAG).count_ones() as u32
     }
 
+    pub fn num_records(&self) -> u16 {
+        self.records.len() as u16
+    }
+
     pub(crate) fn write<W: io::Write>(&self, w: &mut Writer<W>) -> io::Result<()> {
         for &record in &self.records {
             w.write_be(record.0)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ impl Mobi {
         Record::parse_records(
             &self.content,
             &self.metadata.records.records,
-            self.metadata.records.extra_bytes,
+            self.metadata.records.extra_bytes(),
             self.metadata.palmdoc.compression_enum(),
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) mod book;
 pub(crate) mod lz77;
 pub(crate) mod reader;
 pub(crate) mod record;
+use crate::reader::Writer;
 #[cfg(feature = "time")]
 use chrono::NaiveDateTime;
 use headers::TextEncoding;
@@ -88,6 +89,18 @@ impl Mobi {
             content: reader.read_to_end()?,
             metadata,
         })
+    }
+
+    fn write(&self, writer: &mut impl io::Write) -> io::Result<()> {
+        let mut w = Writer::new(writer);
+
+        self.metadata.write_into(&mut w)?;
+
+        let first_offset = self.metadata.records.records[1].0 as usize;
+        let fill = first_offset - w.bytes_written();
+        w.write_be(vec![0; fill])?;
+        // TODO: Consider record compression and everything else.
+        w.write_be(&self.content[first_offset..])
     }
 
     /// Returns an author of this book

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -32,7 +32,7 @@ impl<R: std::io::Read> Reader<R> {
     }
 
     pub(crate) fn get_position(&self) -> usize {
-        self.position as usize
+        self.position
     }
 
     #[inline]
@@ -77,5 +77,85 @@ impl<R: std::io::Read> Reader<R> {
         self.read_exact(&mut buf)?;
 
         Ok(String::from_utf8_lossy(&buf).to_owned().to_string())
+    }
+}
+
+pub(crate) trait WriteBeBytes {
+    fn write_be_bytes<W: io::Write>(&self, writer: &mut W) -> io::Result<usize>;
+}
+
+impl WriteBeBytes for &[u8] {
+    fn write_be_bytes<W: io::Write>(&self, writer: &mut W) -> io::Result<usize> {
+        writer.write_all(self)?;
+        Ok(self.len())
+    }
+}
+
+impl WriteBeBytes for Vec<u8> {
+    fn write_be_bytes<W: io::Write>(&self, writer: &mut W) -> io::Result<usize> {
+        writer.write_all(self)?;
+        Ok(self.len())
+    }
+}
+
+impl WriteBeBytes for &Vec<u8> {
+    fn write_be_bytes<W: io::Write>(&self, writer: &mut W) -> io::Result<usize> {
+        writer.write_all(self)?;
+        Ok(self.len())
+    }
+}
+
+impl WriteBeBytes for u8 {
+    fn write_be_bytes<W: io::Write>(&self, writer: &mut W) -> io::Result<usize> {
+        writer.write_all(&self.to_be_bytes())?;
+        Ok(self.to_be_bytes().len())
+    }
+}
+
+impl WriteBeBytes for u16 {
+    fn write_be_bytes<W: io::Write>(&self, writer: &mut W) -> io::Result<usize> {
+        writer.write_all(&self.to_be_bytes())?;
+        Ok(self.to_be_bytes().len())
+    }
+}
+
+impl WriteBeBytes for u32 {
+    fn write_be_bytes<W: io::Write>(&self, writer: &mut W) -> io::Result<usize> {
+        writer.write_all(&self.to_be_bytes())?;
+        Ok(self.to_be_bytes().len())
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+/// Helper struct for reading header values from content.
+/// Only allows forward reads.
+pub(crate) struct Writer<W> {
+    writer: W,
+    bytes_written: usize,
+}
+
+impl<W: std::io::Write> Writer<W> {
+    pub(crate) fn new(writer: W) -> Writer<W> {
+        Writer {
+            writer,
+            bytes_written: 0,
+        }
+    }
+
+    pub(crate) fn bytes_written(&self) -> usize {
+        self.bytes_written
+    }
+
+    #[inline]
+    pub(crate) fn write_be<B: WriteBeBytes>(&mut self, b: B) -> io::Result<()> {
+        self.bytes_written += b.write_be_bytes(&mut self.writer)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn write_string_be<S: AsRef<str>>(&mut self, s: S, pad: usize) -> io::Result<()> {
+        let mut s_bytes: Vec<_> = s.as_ref().bytes().collect();
+        s_bytes.extend(std::iter::repeat(0).take(pad.saturating_sub(s_bytes.len())));
+        self.write_be(s_bytes)
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -31,10 +31,6 @@ impl<R: std::io::Read> Reader<R> {
         Ok(())
     }
 
-    pub(crate) fn get_position(&self) -> usize {
-        self.position
-    }
-
     #[inline]
     pub(crate) fn set_position(&mut self, p: usize) -> io::Result<()> {
         debug_assert!(p >= self.position, "{}, {}", p, self.position);


### PR DESCRIPTION
This implements most of the functionality for writing headers (#16), though a few questions remain - particularly:

Should we write exactly what was in the file? For instance, should ExtHeader write records in their original order, and should it write duplicate headers?

For specific fields, do we write the expected bytes (per https://wiki.mobileread.com/wiki/MOBI, some bytes are expected to be 0 or 1 or 0xFFFF_FFFF), or the bytes we read?

What should we write for `header.modified`?

Should we use MobiHeader.first_content_record as the starting record to return?

Should readable_records_range() use the first and last content records from self.mobi (#18)?

At the moment, there are failing tests since ExtHeader has duplicate headers which are not saved.

I've also implemented writing the unmodified content for Mobi itself as a temporary measure, though I'd also like to implement correctly decompressing and then compressing records as well.

In order to ensure that everything in the file is correct, I think we could create a WritableMobi struct which the Mobi converts into, and writes the fields as expected (eg. if number of records change, we need to change things accordingly).

What should be written for creation / modified time? We could use chrono for this?

I also don't think we correctly support the subject record in ExtHeader, which can apparently appear multiple times?